### PR TITLE
Add MockPlatform which mocks Platform interface

### DIFF
--- a/noxtest/test_platform.go
+++ b/noxtest/test_platform.go
@@ -4,7 +4,7 @@ import (
 	"time"
 )
 
-// Platform implementation mock to allow test using ticks
+// MockPlatform is a mock Platform implementation to allow test using ticks
 type MockPlatform struct {
 	T time.Duration
 }

--- a/noxtest/test_platform.go
+++ b/noxtest/test_platform.go
@@ -1,0 +1,32 @@
+package noxtest
+
+import (
+	"time"
+)
+
+// Platform implementation mock to allow test using ticks
+type MockPlatform struct {
+	T time.Duration
+}
+
+func (p *MockPlatform) Ticks() time.Duration {
+	return p.T
+}
+
+func (p *MockPlatform) Sleep(dt time.Duration) {
+	p.T = dt
+}
+
+func (p *MockPlatform) TimeSeed() int64 {
+	return 0
+}
+
+func (p *MockPlatform) RandInt() int {
+	return 0
+}
+
+func (p *MockPlatform) RandSeed(seed int64) {
+}
+
+func (p *MockPlatform) RandSeedTime() {
+}

--- a/noxtest/test_platform.go
+++ b/noxtest/test_platform.go
@@ -14,7 +14,7 @@ func (p *MockPlatform) Ticks() time.Duration {
 }
 
 func (p *MockPlatform) Sleep(dt time.Duration) {
-	p.T = dt
+	p.T += dt
 }
 
 func (p *MockPlatform) TimeSeed() int64 {


### PR DESCRIPTION
It allows an unit test to control clocks.

For usages, see https://github.com/noxworld-dev/opennox/pull/698